### PR TITLE
meta/refactor document lessons library

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,12 @@
         python = pkgs.python311;
       };
 
-      lessonsDocumentation = lessonsLib.generateLessonsDocumentation {lessonsPath = ./lessons;};
+      lessonsDocumentation =
+        lessonsLib.generateLessonsDocumentation
+        {
+          lessonsPath = ./lessons;
+          lessonFile = "lesson.md";
+        };
 
       site = pkgs.stdenvNoCC.mkDerivation {
         name = "modules-lessons-site";

--- a/lib/lessons.nix
+++ b/lib/lessons.nix
@@ -116,6 +116,33 @@
     )
   );
 
+  /*
+  Create a fenced code block with language identifier and file name given a file.
+
+  # Example
+
+  ````nix
+  makeFencedCodeBlock ./eval.nix
+  => ''
+  ``` nix title="eval.nix"
+  let
+    a = 1;
+  in
+    a
+  ```
+  ''
+  ````
+
+  # Type
+
+  ```
+  makeFencedCodeBlock :: Path -> String
+  ```
+
+  # Arguments
+
+  - [path] The file.
+  */
   makeFencedCodeBlock = file: ''
     ``` ${getFileExtension file} title="${builtins.baseNameOf file}"
     ${builtins.readFile file}

--- a/lib/lessons.nix
+++ b/lib/lessons.nix
@@ -4,6 +4,30 @@
   lib,
   ...
 }: rec {
+  /*
+  Creates an attrset where the key is the lesson directory name and the value is the path to the directory.
+
+  # Example
+
+  ```nix
+  getLessons
+  {lessonsPath = ../lessons;}
+  => {
+    "001-a-module" = <nix-store>/lessons/001-a-module;
+    "010-basic-types" = <nix-store>/lessons/010-basic-types;
+    }
+  ```
+
+  # Type
+
+  ```
+  getLessons :: Attrset -> Attrset
+  ```
+
+  # Arguments
+
+  - [lessonsPath] The path to the lessons directory.
+  */
   getLessons = {lessonsPath ? ../lessons, ...}: (
     lib.mapAttrs
     (name: _: lib.path.append lessonsPath name)

--- a/lib/lessons.nix
+++ b/lib/lessons.nix
@@ -149,6 +149,9 @@
     ```
   '';
 
+  /*
+  Given a lesson, create the metadata necessary to create the markdown documentation.
+  */
   createLessonMetadata = {lessonFile ? "lesson.md", ...}: name: value: let
     lessonDir = name;
     lessonPath = value;
@@ -212,12 +215,18 @@
       .config;
   };
 
-  lessonsToMetadata = {lessonsPath ? ../lessons, ...} @ args: (
+  /*
+  Maps over all the lessons and generates metadata.
+  */
+  lessonsToMetadata = args: (
     lib.mapAttrs
     (createLessonMetadata args)
     (getLessons args)
   );
 
+  /*
+  Given a list of lesson metadata attrsets, copy the contents to the nix store.
+  */
   copyLessonsToNixStore = lessons:
     pkgs.runCommand
     "copy-module-lessons"
@@ -243,6 +252,11 @@
       }
     '';
 
+  /*
+  Primary function for building lesson documentation.
+
+  Is used when building the site.
+  */
   generateLessonsDocumentation = args: (
     copyLessonsToNixStore
     (
@@ -251,6 +265,11 @@
     )
   );
 
+  /*
+  Builds the lessons documentation and copies it to the needed location in the mkdocs directory.
+
+  Primary use is for developing with `mkdocs serve`.
+  */
   copyLessonsToSite =
     pkgs.writeShellScriptBin
     "copy-lessons-to-site"


### PR DESCRIPTION
- Add doc-comment for getFileExtension.
- Rename findStrings to multilineMatch and add doc-comment.
- Create makeFencedCodeBlock expression.
- Refactor createLessonMetadata to accept an attrset for high level arguments.
- Refactor createLessonMetadata to use more of the new functions.
- Refactor createLessonMetadata by moving keys that don't need to be in the output to the let/in block.
- Refactor filesToSubstitute to append the parent path to the file name.
- Refactor textToSubstitute to use the new makeFencedCodeBlock expression.
- Add doc-comment for makeFencedCodeBlock.
- Add comments for all the higher level functions that create metadata or building markdown documentation.
- Add doc-comment for getLessons.