### PR TITLE
site/make mechanism for eval substitution

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,19 +30,18 @@
         mkPoetryEnv
         ;
 
-      lessonsLib = import ./lib/lessons.nix {inherit self pkgs lib;};
+      lessonsLib = import ./lib/lessons.nix {inherit pkgs lib;};
 
       site-env = mkPoetryEnv {
         projectDir = self + /site;
         python = pkgs.python311;
       };
 
-      lessonsDocumentation =
-        lessonsLib.generateLessonsDocumentation
-        {
-          lessonsPath = ./lessons;
-          lessonFile = "lesson.md";
-        };
+      lessonsInfo = {
+        lessonsPath = ./lessons;
+        lessonFile = "lesson.md";
+      };
+      lessonsDocumentation = lessonsLib.generateLessonsDocumentation lessonsInfo;
 
       site = pkgs.stdenvNoCC.mkDerivation {
         name = "modules-lessons-site";

--- a/lessons/001-a-module/eval.nix
+++ b/lessons/001-a-module/eval.nix
@@ -1,6 +1,4 @@
-let
-  pkgs = import <nixpkgs> {};
-
+{pkgs}: let
   mymodule = {
     imports = [
     ];

--- a/lessons/010-basic-types/eval.nix
+++ b/lessons/010-basic-types/eval.nix
@@ -1,13 +1,10 @@
-let
-  pkgs = import <nixpkgs> {};
-  inherit (pkgs) lib;
-in
-  (
-    pkgs.lib.evalModules {
-      modules = [
-        ./options.nix
-        ./config.nix
-      ];
-    }
-  )
-  .config
+{pkgs}:
+(
+  pkgs.lib.evalModules {
+    modules = [
+      ./options.nix
+      ./config.nix
+    ];
+  }
+)
+.config

--- a/lessons/010-basic-types/lesson.md
+++ b/lessons/010-basic-types/lesson.md
@@ -26,6 +26,6 @@ In the `run.sh` file, we evaluate the `eval.nix` file and have it print out a ni
 
 If you execute the run file (`./run.sh`), you should see an output that matches what we have configured.
 
-[//]: # (evaluatedLesson)
+[//]: # (self.eval)
 
 [nixos-manual-basic-types]: https://nixos.org/manual/nixos/stable/#sec-option-types

--- a/lessons/010-basic-types/run.sh
+++ b/lessons/010-basic-types/run.sh
@@ -1,1 +1,1 @@
-nix eval -f eval.nix --json | nix run nixpkgs#jq -- .
+nix eval -f eval.nix --apply 'x: x {pkgs = import <nixpkgs> {};}' --json | nix run nixpkgs#jq -- .


### PR DESCRIPTION
Created a new function that searches for `eval` files in the lesson directory and evalutes them. They can be used in the lesson.md file by using a hidden comment with a value of `self.<eval file>` (e.g. `self.eval`). The extension is not used. Refactored the lessons library to use this new feature and udpated any necessary lesson files.