### PR TITLE
nix/use-filesets

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
     flake-utils.lib.eachSystem ["x86_64-linux"] (system: let
       pkgs = nixpkgs.legacyPackages.${system};
       lib = pkgs.lib;
+      inherit (lib) fileset;
       inherit
         (poetry2nix.lib.mkPoetry2Nix {inherit pkgs;})
         mkPoetryEnv
@@ -33,19 +34,30 @@
       lessonsLib = import ./lib/lessons.nix {inherit pkgs lib;};
 
       site-env = mkPoetryEnv {
-        projectDir = self + /site;
+        projectDir = fileset.toSource {
+          root = ./site;
+          fileset = fileset.unions [./site];
+        };
         python = pkgs.python311;
       };
 
       lessonsInfo = {
-        lessonsPath = ./lessons;
+        lessonsPath = (
+          fileset.toSource {
+            root = ./lessons;
+            fileset = fileset.unions [./lessons];
+          }
+        );
         lessonFile = "lesson.md";
       };
       lessonsDocumentation = lessonsLib.generateLessonsDocumentation lessonsInfo;
 
       site = pkgs.stdenvNoCC.mkDerivation {
         name = "modules-lessons-site";
-        src = self + "/site";
+        src = fileset.toSource {
+          root = ./site;
+          fileset = fileset.unions [./site];
+        };
         nativeBuildInputs = [site-env];
 
         buildPhase = ''

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,10 @@
       site-env = mkPoetryEnv {
         projectDir = fileset.toSource {
           root = ./site;
-          fileset = ./site;
+          fileset = fileset.unions [
+            ./site/pyproject.toml
+            ./site/poetry.lock
+          ];
         };
         python = pkgs.python311;
       };
@@ -56,7 +59,13 @@
         name = "modules-lessons-site";
         src = fileset.toSource {
           root = ./site;
-          fileset = ./site;
+          fileset =
+            fileset.difference
+            ./site
+            (fileset.unions [
+              ./site/pyproject.toml
+              ./site/poetry.lock
+            ]);
         };
         nativeBuildInputs = [site-env];
 

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
       site-env = mkPoetryEnv {
         projectDir = fileset.toSource {
           root = ./site;
-          fileset = fileset.unions [./site];
+          fileset = ./site;
         };
         python = pkgs.python311;
       };
@@ -45,7 +45,7 @@
         lessonsPath = (
           fileset.toSource {
             root = ./lessons;
-            fileset = fileset.unions [./lessons];
+            fileset = ./lessons;
           }
         );
         lessonFile = "lesson.md";
@@ -56,7 +56,7 @@
         name = "modules-lessons-site";
         src = fileset.toSource {
           root = ./site;
-          fileset = fileset.unions [./site];
+          fileset = ./site;
         };
         nativeBuildInputs = [site-env];
 

--- a/lib/lessons.nix
+++ b/lib/lessons.nix
@@ -29,7 +29,7 @@
   */
   getLessons = {lessonsPath ? ../lessons, ...}: (
     lib.mapAttrs
-    (name: _: lib.path.append lessonsPath name)
+    (name: _: lessonsPath + "/" + name)
     (
       lib.filterAttrs
       (name: type: type == "directory")
@@ -184,7 +184,7 @@
     (
       builtins.map
       (path: {
-        name = "${lib.removeSuffix ".nix" (builtins.baseNameOf path)}";
+        name = "${builtins.unsafeDiscardStringContext (lib.removeSuffix ".nix" (builtins.baseNameOf path))}";
         value = lib.generators.toPretty {} (import path {inherit pkgs;});
       })
       (
@@ -201,7 +201,7 @@
   createLessonMetadata = {lessonFile ? "lesson.md", ...}: name: value: let
     lessonDir = name;
     lessonPath = value;
-    rawLesson = builtins.readFile (lib.path.append lessonPath lessonFile);
+    rawLesson = builtins.readFile (lessonPath + "/" + lessonFile);
 
     commentLineMatch = ''(\[//]: # \(\./.*\))'';
     commentFileMatch = ''\[//]: # \(\./(.*)\)'';
@@ -209,8 +209,10 @@
     filesToSubstitute = (
       builtins.map
       (
-        lib.path.append
-        lessonPath
+        x:
+          lessonPath
+          + "/"
+          + x
       )
       (
         lib.flatten
@@ -270,8 +272,8 @@
       (
         lib.evalModules {
           modules = [
-            (lib.path.append lessonPath "options.nix")
-            (lib.path.append lessonPath "config.nix")
+            (lessonPath + "/" + "options.nix")
+            (lessonPath + "/" + "config.nix")
           ];
         }
       )

--- a/lib/lessons.nix
+++ b/lib/lessons.nix
@@ -208,12 +208,7 @@
     linesToReplace = multilineMatch commentLineMatch rawLesson;
     filesToSubstitute = (
       builtins.map
-      (
-        x:
-          lessonPath
-          + "/"
-          + x
-      )
+      (x: lessonPath + "/" + x)
       (
         lib.flatten
         (
@@ -268,16 +263,6 @@
         rawLesson
       )
     );
-    evaluatedLesson =
-      (
-        lib.evalModules {
-          modules = [
-            (lessonPath + "/" + "options.nix")
-            (lessonPath + "/" + "config.nix")
-          ];
-        }
-      )
-      .config;
   };
 
   /*


### PR DESCRIPTION
Replaced path or strings paths with filesets.

Now the critical derivations (the dependency environment, the lessons, and the site) are not tied to the entire repository. The derivation closure is scoped to only what is necessary and should save on build times and creating unnecessary derivations if something unrelated changes (e.g. in the flake file).