### PR TITLE
lesson/move function arguments

### DIFF
--- a/lessons/001-a-module/lesson.md
+++ b/lessons/001-a-module/lesson.md
@@ -121,37 +121,4 @@ When we evaluate our modules, we can simply include both files.
 As long as every definition has a declaration, we can successfully evaluate our modules.
 If there is an option definition that has not been declared, the module system will throw an error.
 
-## Function Arguments
-
-When you define a module as a function like we did previously, there are certain arguments that are automatically provided.
-You ***do not*** have to explicitely put them in the function signature as we have the ellipsis `...` to manage any arguments we do not use.
-
-All modules are passed the following arguments:
-
-- `lib`: The nixpkgs library.
-- `config`: The results of all options after merging the values from all modules together.
-- `options`: The options declared in all modules.
-- `specialArgs`: An attribute set of extra arguments to be passed to the module functions.
-- All attributes of `specialArgs`.
-
-!!! note
-    The fact that all the attributes of `specialArgs` are automatically provided means you don't need to add `specialArgs` to the module function signature if we want access to `specialArgs.thing`.
-    We can just add `thing` to the function signature and use it directly.
-
-When designing a module for NixOS, there are some additional arguments that are automatically provided:
-
-- `pkgs`: The nixpkgs package set according to the `nixpkgs.pkgs` option.
-- `modulesPath`: The path to the NixOS modules directory in the nixpkgs repository.
-
-`modulesPath` is very handy as it allows you to import extra modules from the nixpkgs package tree without having to somehow make the module aware of the location of the `nixpkgs` or NixOS directories.
-It allows you to do things like this:
-
-``` nix
-{ modulesPath, ... }: {
-  imports = [
-    (modulesPath + "/profiles/minimal.nix")
-  ];
-}
-```
-
 [option-types-basic]: https://nixos.org/manual/nixos/stable/#sec-option-types-basic

--- a/lessons/function-arguments/lesson.md
+++ b/lessons/function-arguments/lesson.md
@@ -1,0 +1,33 @@
+# Function Arguments
+
+When you define a module as a function like we did previously, there are certain arguments that are automatically provided.
+You ***do not*** have to explicitely put them in the function signature as we have the ellipsis `...` to manage any arguments we do not use.
+
+All modules are passed the following arguments:
+
+- `lib`: The nixpkgs library.
+- `config`: The results of all options after merging the values from all modules together.
+- `options`: The options declared in all modules.
+- `specialArgs`: An attribute set of extra arguments to be passed to the module functions.
+- All attributes of `specialArgs`.
+
+!!! note
+    The fact that all the attributes of `specialArgs` are automatically provided means you don't need to add `specialArgs` to the module function signature if we want access to `specialArgs.thing`.
+    We can just add `thing` to the function signature and use it directly.
+
+When designing a module for NixOS, there are some additional arguments that are automatically provided:
+
+- `pkgs`: The nixpkgs package set according to the `nixpkgs.pkgs` option.
+- `modulesPath`: The path to the NixOS modules directory in the nixpkgs repository.
+
+`modulesPath` is very handy as it allows you to import extra modules from the nixpkgs package tree without having to somehow make the module aware of the location of the `nixpkgs` or NixOS directories.
+It allows you to do things like this:
+
+``` nix
+{ modulesPath, ... }: {
+  imports = [
+    (modulesPath + "/profiles/minimal.nix")
+  ];
+}
+```
+

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -15,6 +15,7 @@ nav:
       - lessons/composed-types/lesson.md
       - lessons/submodule-types/lesson.md
     - Misc:
+      - lessons/function-arguments/lesson.md
       - lessons/default-behavior/lesson.md
       - lessons/merging-attrsof/lesson.md
       - lessons/merging-listof/lesson.md


### PR DESCRIPTION
Moved the Function Arguments section from What is a Module to its own lesson. Trying to minimize the amount of theory before showing practical examples.